### PR TITLE
Persist sort order returned by normalizr

### DIFF
--- a/src/base_config.js
+++ b/src/base_config.js
@@ -25,6 +25,7 @@ class BaseConfig {
   static initialState = {
     loading: false,
     errors: {},
+    sortedIds: [],
     data: {},
   }
 
@@ -121,9 +122,9 @@ class BaseConfig {
     const { _parse, schema } = this;
     const parsable = isArray(response) ? response : [response];
     const parsed = _parse(parsable);
-    const { entities } = normalize(parsed, [schema]);
+    const { entities, result } = normalize(parsed, [schema]);
 
-    return thunk(entities);
+    return thunk({ sortedIds: result, ...entities });
   }
 
   // PRIVATE METHODS

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,5 @@
+import _uniq from 'lodash/uniq';
+import _without from 'lodash/without';
 import BaseConfig from './base_config';
 import helpers from './helpers';
 
@@ -34,6 +36,7 @@ class ReduxEntityConfig extends BaseConfig {
             ...state,
             loading: false,
             errors: {},
+            sortedIds: payload.data.sortedIds,
             data: {
               ...payload.data[entityName],
             },
@@ -45,6 +48,7 @@ class ReduxEntityConfig extends BaseConfig {
             ...state,
             loading: false,
             errors: {},
+            sortedIds: _uniq([...state.sortedIds, ...payload.data.sortedIds]),
             data: {
               ...state.data,
               ...payload.data[entityName],
@@ -55,6 +59,7 @@ class ReduxEntityConfig extends BaseConfig {
             ...state,
             loading: false,
             errors: {},
+            sortedIds: _without(state.sortedIds, payload.data.id),
             data: {
               ...entitiesExceptID(state.data, payload.data.id),
             },

--- a/test/config_reducer.tests.js
+++ b/test/config_reducer.tests.js
@@ -12,6 +12,7 @@ const schemas = {
 describe('ReduxEntityConfig - reducer', () => {
   const state = {
     loading: false,
+    sortedIds: [userStub.id],
     errors: {},
     data: {
       [userStub.id]: userStub,
@@ -54,10 +55,20 @@ describe('ReduxEntityConfig - reducer', () => {
         expect(newState).toEqual({
           loading: false,
           errors: {},
+          sortedIds: [userStub.id],
           data: {
             [userStub.id]: userStub,
           },
         });
+      });
+
+      it('appends the id to sortedIds', () => {
+        const createSuccessAction = actions.successAction([userStub], actions.createSuccess);
+        const initialState = { ...ReduxEntityConfig.initialState, sortedIds: [0, 2] };
+
+        const newState = reducer(initialState, createSuccessAction);
+
+        expect(newState.sortedIds).toEqual([0, 2, 1]);
       });
     });
 
@@ -71,6 +82,7 @@ describe('ReduxEntityConfig - reducer', () => {
         expect(newState).toEqual({
           loading: false,
           errors,
+          sortedIds: [],
           data: {},
         });
       });
@@ -93,8 +105,18 @@ describe('ReduxEntityConfig - reducer', () => {
         expect(newState).toEqual({
           loading: false,
           errors: {},
+          sortedIds: [],
           data: {},
         });
+      });
+
+      it('removes the id from sortedIds', () => {
+        const destroySuccessAction = actions.destroySuccess({ id: userStub.id });
+        const initialState = { ...ReduxEntityConfig.initialState, sortedIds: [userStub.id, 2, 3] };
+
+        const newState = reducer(initialState, destroySuccessAction);
+
+        expect(newState.sortedIds).toEqual([2, 3]);
       });
     });
 
@@ -129,10 +151,29 @@ describe('ReduxEntityConfig - reducer', () => {
         expect(newState).toEqual({
           loading: false,
           errors: {},
+          sortedIds: [userStub.id],
           data: {
             [userStub.id]: userStub,
           },
         });
+      });
+
+      it('appends a new user to the end of sortedIds', () => {
+        const loadSuccessAction = actions.successAction([userStub], actions.loadSuccess);
+
+        const initialState = { ...ReduxEntityConfig.initialState, sortedIds: [0, 2] };
+        const newState = reducer(initialState, loadSuccessAction);
+
+        expect(newState.sortedIds).toEqual([0, 2, 1]);
+      });
+
+      it('leaves an existing user in place in sortedIds', () => {
+        const loadSuccessAction = actions.successAction([userStub], actions.loadSuccess);
+
+        const initialState = { ...ReduxEntityConfig.initialState, sortedIds: [0, 1, 2] };
+        const newState = reducer(initialState, loadSuccessAction);
+
+        expect(newState.sortedIds).toEqual([0, 1, 2]);
       });
     });
 
@@ -146,6 +187,7 @@ describe('ReduxEntityConfig - reducer', () => {
         expect(newState).toEqual({
           loading: false,
           errors,
+          sortedIds: [],
           data: {},
         });
       });
@@ -169,6 +211,7 @@ describe('ReduxEntityConfig - reducer', () => {
         expect(newState).toEqual({
           loading: false,
           errors: {},
+          sortedIds: [101],
           data: {
             101: newUser,
           },
@@ -187,16 +230,24 @@ describe('ReduxEntityConfig - reducer', () => {
 
     describe('successful action', () => {
       const updateSuccessAction = actions.successAction([newUser], actions.updateSuccess);
-      const newState = reducer(state, updateSuccessAction);
 
       it('replaces the user in state', () => {
+        const newState = reducer(state, updateSuccessAction);
+
         expect(newState).toEqual({
           loading: false,
           errors: {},
+          sortedIds: [userStub.id],
           data: {
             [userStub.id]: newUser,
           },
         });
+      });
+
+      it('leaves the id in place in sortedIds', () => {
+        const newState = reducer({ ...state, sortedIds: [0, 1, 2] }, updateSuccessAction);
+
+        expect(newState.sortedIds).toEqual([0, 1, 2]);
       });
     });
 
@@ -221,6 +272,7 @@ describe('ReduxEntityConfig - reducer', () => {
       errors: {
         base: 'User is not authenticated',
       },
+      sortedIds: [userStub.id],
       data: {
         [userStub.id]: userStub,
       },

--- a/test/config_thunks.tests.js
+++ b/test/config_thunks.tests.js
@@ -72,6 +72,7 @@ describe('ReduxEntityConfig - thunks', () => {
             expect(dispatchedActionTypes).toNotInclude('users_CREATE_FAILURE');
             expect(successAction.payload).toEqual({
               data: {
+                sortedIds: [userStub.id],
                 users: {
                   [userStub.id]: userStub,
                 },
@@ -140,6 +141,7 @@ describe('ReduxEntityConfig - thunks', () => {
       const mockStore = reduxMockStore({
         ...store,
         data: { [userStub.id]: userStub },
+        sortedIds: [userStub.id],
       });
 
       it('calls the destroyFunc', () => {
@@ -173,7 +175,7 @@ describe('ReduxEntityConfig - thunks', () => {
             const state = mockStore.getState();
 
             expect(destroySuccessAction.payload).toEqual({ data: { id: userStub.id } });
-            expect(config.reducer(state, destroySuccessAction)).toEqual(store);
+            expect(config.reducer(state, destroySuccessAction)).toEqual({ ...store, sortedIds: [] });
           });
       });
     });


### PR DESCRIPTION
When data is returned from a REST API in an array
It often has a useful sort order
That should be available to client code.

This data is returned from the normalizr.normalize
Function as `result`, but currently only `entities`
Are persisted.

Addresses https://github.com/TheGnarCo/redux-entity-config/issues/17